### PR TITLE
fix setup:env script command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "setup": "npm run setup:env && npm run setup:web && echo '\n✅ Setup complete! Please update your .env files with your API keys.\n📖 See README.md for detailed instructions.'",
     "setup:env": "cp .env.example .env && echo '📝 Created .env file'",
-    "setup:web": "cd web-interface && cp env.example .env.local && echo '📝 Created web-interface/.env.local file'",
+    "setup:web": "cd web-interface && cp .env.example .env.local && echo '📝 Created web-interface/.env.local file'",
     "dev": "tsx watch src/index.ts",
     "dev:bot": "tsx watch --clear-screen=false src/index.ts",
     "dev:web": "cd web-interface && npm run dev",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "setup": "npm run setup:env && npm run setup:web && echo '\n✅ Setup complete! Please update your .env files with your API keys.\n📖 See README.md for detailed instructions.'",
-    "setup:env": "cp env.example .env && echo '📝 Created .env file'",
+    "setup:env": "cp .env.example .env && echo '📝 Created .env file'",
     "setup:web": "cd web-interface && cp env.example .env.local && echo '📝 Created web-interface/.env.local file'",
     "dev": "tsx watch src/index.ts",
     "dev:bot": "tsx watch --clear-screen=false src/index.ts",


### PR DESCRIPTION
The setup:env script references `env.example` but the file in the repo is `.env.example`

This change updates the script to match the correct filename, allowing npm run setup to succeed.